### PR TITLE
fix: disable i2c logging for both i2c twi and twim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+-   Fix the disable logging logic in `notecard_is_present` to not assert if `i2c_nrfx_twim` is being used instead of `i2c_nrfx_twi`.
+
 ## [1.4.2] - 2023-11-30
 
 ### Changed


### PR DESCRIPTION
## Description

Previously, the code would assert it i2c_nrfx_twi was not being used, although i2c_nrfx_twim is also a valid option.

We now check for both i2c_nrfx_twi and i2c_nrfx_twim, and disable logging for the existing option.
If neither is used, we do not disable logging (and do not assert)

## Areas of interest for the reviewer

All

## Checklist

<!--- Check items that you fulfilled, strikeout the ones that do not apply and write why  -->

- [x] My code follows the [style guidelines] as defined by IRNAS.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] I added/updated source code documentation for all newly added or changed
      functions.
- [x] I updated all customer-facing technical documentation.

## After-review steps

<!--- Delete section or select one option -->

- I will merge PR by myself.

[style guidelines]:
  https://github.com/IRNAS/irnas-guidelines-docs/blob/main/docs/developer_guidelines.md
